### PR TITLE
Test on PHP 8.2 and drop support for 7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: ['ubuntu-latest']
-        php-version: ['7.3', '7.4', '8.0', '8.1']
-        composer-version: ['composer:v1', 'composer:v2']
+        php-version: ['7.4', '8.0', '8.1', '8.2']
+        composer-version: ['composer:v2']
 
     steps:
       - name: Checkout
@@ -26,7 +26,7 @@ jobs:
           extensions: mbstring, xdebug, pcov
 
       - name: Install dependencies
-        run: composer install --no-progress --no-suggest --prefer-dist
+        run: composer install --no-progress --prefer-dist
 
       - name: Test
         run: composer run test


### PR DESCRIPTION
Also dropped Composer v1 tests, since Composer v1
is no longer maintained.